### PR TITLE
Add unsafe memcmp operations

### DIFF
--- a/lib/bigstringaf.ml
+++ b/lib/bigstringaf.ml
@@ -28,6 +28,12 @@ external unsafe_blit_from_bytes : Bytes.t -> src_off:int -> t       -> dst_off:i
 external unsafe_blit_from_string : string -> src_off:int -> t       -> dst_off:int -> len:int -> unit =
   "bigstringaf_blit_from_bytes"   [@@noalloc]
 
+external unsafe_memcmp : t -> int -> t -> int -> int -> int =
+  "bigstringaf_memcmp_bigstring" [@@noalloc]
+
+external unsafe_memcmp_string : t -> int -> string -> int -> int -> int =
+  "bigstringaf_memcmp_string" [@@noalloc]
+
 let sub t ~off ~len =
   BA1.sub t off len
 

--- a/lib/bigstringaf.mli
+++ b/lib/bigstringaf.mli
@@ -221,3 +221,15 @@ val unsafe_blit_from_string : string  -> src_off:int -> t -> dst_off:int -> len:
 val unsafe_blit_from_bytes  : Bytes.t -> src_off:int -> t -> dst_off:int -> len:int -> unit
 
 val unsafe_blit_to_bytes : t -> src_off:int -> Bytes.t -> dst_off:int -> len:int -> unit
+
+(** {3 [memcmp]}
+
+    Fast comparisions based on [memcmp]. Simliar to the blits, these are not
+    memory safe and are implemented by the same C call:
+
+      {[
+        memcmp(buf1 + off1, buf2 + off2, len);
+      ]} *)
+
+val unsafe_memcmp        : t -> int -> t      -> int -> int -> int
+val unsafe_memcmp_string : t -> int -> string -> int -> int -> int

--- a/lib/bigstringaf_stubs.c
+++ b/lib/bigstringaf_stubs.c
@@ -61,3 +61,25 @@ bigstringaf_blit_from_bytes(value vsrc, value vsrc_off, value vdst, value vdst_o
     size_t len = Long_val(vlen);
     memcpy(dst, src, len);
 }
+
+CAMLprim value
+bigstringaf_memcmp_bigstring(value vba1, value vba1_off, value vba2, value vba2_off, value vlen)
+{
+    void *ba1 = ((char *)Caml_ba_data_val(vba1)) + Long_val(vba1_off),
+         *ba2 = ((char *)Caml_ba_data_val(vba2)) + Long_val(vba2_off);
+    size_t len = Long_val(vlen);
+
+    int result = memcmp(ba1, ba2, len);
+    return Val_int(result);
+}
+
+CAMLprim value
+bigstringaf_memcmp_string(value vba, value vba_off, value vstr, value vstr_off, value vlen)
+{
+    void *buf1 = ((char *)Caml_ba_data_val(vba)) + Long_val(vba_off),
+         *buf2 = ((char *)String_val(vstr))      + Long_val(vstr_off);
+    size_t len = Long_val(vlen);
+
+    int result = memcmp(buf1, buf2, len);
+    return Val_int(result);
+}

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -54,3 +54,23 @@ function bigstringaf_blit_from_bytes(src, src_off, dst, dst_off, len) {
     caml_ba_set_1(dst, dst_off + i, caml_string_unsafe_get(src, src_off + i));
   }
 }
+
+//Provides: bigstringaf_memcmp_bigstring
+//Requres: caml_ba_get_1, caml_int_compare
+function bigstringaf_memcmp_bigstring(ba1, ba1_off, ba2, ba2_off, len) {
+  for (var i = 0; i < len; i++) {
+    var c = caml_int_compare(caml_ba_get_1(ba1, ba1_off + i), caml_ba_get_1(ba2, ba2_off + i));
+    if (c != 0) return c
+  }
+  return 0;
+}
+
+//Provides: bigstringaf_memcmp_string
+//Requres: caml_ba_get_1, caml_int_compare, caml_string_unasfe_get
+function bigstringaf_memcmp_string(ba, ba_off, str, str_off, len) {
+  for (var i = 0; i < len; i++) {
+    var c = caml_int_compare(caml_ba_get_1(ba, ba_off + i), caml_string_unsafe_get(str, str_off + i));
+    if (c != 0) return c
+  }
+  return 0;
+}

--- a/lib_test/test_bigstringaf.ml
+++ b/lib_test/test_bigstringaf.ml
@@ -143,9 +143,10 @@ let unsafe_operations =
   [ "getters"            , `Quick, getters (module Getters)
   ; "setters"            , `Quick, setters (module Setters) ]
 
+let string1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+let string2 = "abcdefghijklmnopqrstuvwxyz"
+
 let unsafe_blit () =
-  let string1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" in
-  let string2 = "abcdefghijklmnopqrstuvwxyz" in
   let with_buffers ~f =
     let buffer1 = Bigstringaf.of_string string1 ~off:0 ~len:(String.length string1) in
     let buffer2 = Bigstringaf.of_string string2 ~off:0 ~len:(String.length string2) in
@@ -178,8 +179,6 @@ let unsafe_blit () =
 ;;
 
 let unsafe_blit_to_bytes   () =
-  let string1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" in
-  let string2 = "abcdefghijklmnopqrstuvwxyz" in
   let with_buffers ~f =
     let buffer1 = string1 in
     let buffer2 = Bigstringaf.of_string string2 ~off:0 ~len:(String.length string2) in
@@ -202,8 +201,6 @@ let unsafe_blit_to_bytes   () =
 ;;
 
 let unsafe_blit_from_bytes () =
-  let string1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" in
-  let string2 = "abcdefghijklmnopqrstuvwxyz" in
   let with_buffers ~f =
     let buffer1 = Bytes.of_string string1 in
     let buffer2 = Bigstringaf.of_string string2 ~off:0 ~len:(String.length string2) in
@@ -231,8 +228,43 @@ let blit_operations =
   ; "unsafe_blit_from_bytes", `Quick, unsafe_blit_from_bytes
   ]
 
+let unsafe_memcmp () =
+  let buffer1 = Bigstringaf.of_string ~off:0 ~len:(String.length string1) string1 in
+  let buffer2 = Bigstringaf.of_string ~off:0 ~len:(String.length string2) string2 in
+  Alcotest.(check bool "identical buffers are equal" true
+    (Bigstringaf.unsafe_memcmp buffer1 0 buffer1 0 (Bigstringaf.length buffer1) = 0));
+  Alcotest.(check bool "prefix of identical buffers are equal" true
+    (Bigstringaf.unsafe_memcmp buffer1 0 buffer1 0 (Bigstringaf.length buffer1 - 10 ) = 0));
+  Alcotest.(check bool "suffix of identical buffers are equal" true
+    (Bigstringaf.unsafe_memcmp buffer1 10 buffer1 10 (Bigstringaf.length buffer1 - 10) = 0));
+  Alcotest.(check bool "uppercase is less than uppercase" true
+    (Bigstringaf.unsafe_memcmp buffer1 0 buffer2 0 (Bigstringaf.length buffer1) < 0));
+  Alcotest.(check bool "lowercase is greater than uppercase" true
+    (Bigstringaf.unsafe_memcmp buffer2 0 buffer1 0 (Bigstringaf.length buffer1) > 0));
+;;
+
+let unsafe_memcmp_string () =
+  let buffer1 = Bigstringaf.of_string ~off:0 ~len:(String.length string1) string1 in
+  let buffer2 = Bigstringaf.of_string ~off:0 ~len:(String.length string2) string2 in
+  Alcotest.(check bool "of_string'd and original buffer are equal" true
+    (Bigstringaf.unsafe_memcmp_string buffer1 0 string1 0 (Bigstringaf.length buffer1) = 0));
+  Alcotest.(check bool "prefix of of_string'd and original buffer are equal" true
+    (Bigstringaf.unsafe_memcmp_string buffer1 10 string1 10 (Bigstringaf.length buffer1 - 10) = 0));
+  Alcotest.(check bool "suffix of identical buffers are equal" true
+    (Bigstringaf.unsafe_memcmp_string buffer1 10 string1 10 (Bigstringaf.length buffer1 - 10) = 0));
+  Alcotest.(check bool "uppercase is less than uppercase" true
+    (Bigstringaf.unsafe_memcmp_string buffer1 0 string2 0 (Bigstringaf.length buffer1) < 0));
+  Alcotest.(check bool "lowercase is greater than uppercase" true
+    (Bigstringaf.unsafe_memcmp_string buffer2 0 string1 0 (Bigstringaf.length buffer1) > 0));
+  ()
+
+let memcmp_operations =
+  [ "unsafe_memcmp"       , `Quick, unsafe_memcmp
+  ; "unsafe_memcmp_string", `Quick, unsafe_memcmp_string ]
+
 let () =
   Alcotest.run "test suite"
     [ "safe operations"  , safe_operations
     ; "unsafe operations", unsafe_operations
-    ; "blit operations"  , blit_operations ]
+    ; "blit operations"  , blit_operations
+    ; "memcmp operations", memcmp_operations ]


### PR DESCRIPTION
For fast comparisons on bigstrings and between bigstrings and strings. Most useful for determining equality, but whatever floats your boat.

Like other unsafe operations in this module, no bounds checking is performed.