### PR TITLE
don't generate assembly for lib target

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -6,7 +6,6 @@
   (libraries   (bigarray))
   (c_names (bigstringaf_stubs))
   (c_flags (-Wall -Wextra -Wpedantic))
-  (ocamlopt_flags (:standard -S))
   (flags   (:standard -safe-string))
   (js_of_ocaml (
     (javascript_files (runtime.js))


### PR DESCRIPTION
This was left over from initial implementation. There's no need to keep this around.