### PR TITLE
Less copying around (in xen/freestanding)

### DIFF
--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -19,5 +19,6 @@ depends: [
 ]
 depopts: [
   "mirage-xen-ocaml"
+  "ocaml-freestanding"
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/lib/freestanding/jbuild
+++ b/lib/freestanding/jbuild
@@ -9,8 +9,6 @@
   (c_flags     (:include cflags.sexp))))
 
 (rule (copy# ../bigstringaf_stubs.c bigstringaf_stubs.c))
-(rule (copy# ../bigstringaf.ml bigstringaf.ml))
-(rule (copy# ../bigstringaf.mli bigstringaf.mli))
 
 (rule
  ((targets (cflags.sexp))

--- a/lib/xen/jbuild
+++ b/lib/xen/jbuild
@@ -9,8 +9,6 @@
   (c_flags     (:include cflags.sexp))))
 
 (rule (copy# ../bigstringaf_stubs.c bigstringaf_stubs.c))
-(rule (copy# ../bigstringaf.ml bigstringaf.ml))
-(rule (copy# ../bigstringaf.mli bigstringaf.mli))
 
 (rule
  ((targets (cflags.sexp))


### PR DESCRIPTION
thanks to @dinosaure (in https://github.com/dinosaure/checkseum/pull/6) I discovered there's no need to copy aroung 'bigstringaf.ml` and `bigstringaf.mli` (and recompile them again), but only the C stubs need to be copied.  In addition, the `opam` file now has `ocaml-freestanding` as an optional dependency.