### PR TITLE
opam-fix: add '"-p" name' to subst command

### DIFF
--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/inhabitedtype/bigstringaf"
 bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "https://github.com/inhabitedtype/bigstringaf.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 build-test: [


### PR DESCRIPTION
Related to ocaml/opam-repository#12292.