### PR TITLE
use mirage-xen-posix everywhere

### DIFF
--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -18,7 +18,7 @@ depends: [
   "base-bigarray"
 ]
 depopts: [
-  "mirage-xen-ocaml"
+  "mirage-xen-posix"
   "ocaml-freestanding"
 ]
 available: [ ocaml-version >= "4.03.0" ]

--- a/lib/xen/jbuild
+++ b/lib/xen/jbuild
@@ -4,7 +4,7 @@
  ((name        bigstringaf_xen)
   (public_name bigstringaf.xen)
   (optional)
-  (libraries   (bigarray mirage-xen))
+  (libraries   (bigarray mirage-xen-posix))
   (c_names     (bigstringaf_stubs))
   (c_flags     (:include cflags.sexp))))
 


### PR DESCRIPTION
i believe this is the root cause for https://github.com/reynir/qubes-mirage-ssh-agent/issues/7

see https://github.com/ocaml/opam-repository/pull/12724 for a temporary (incorrect) fix for the 0.3 release.