### PR TITLE
Fix the generation of flags for freestanding

### DIFF
--- a/lib/freestanding/jbuild
+++ b/lib/freestanding/jbuild
@@ -10,4 +10,4 @@
 
 (rule (copy# ../bigstringaf_stubs.c bigstringaf_stubs.c))
 
-(rule (with-stdout-to cflags.sexp (run cflags.sh)))
+(rule (with-stdout-to cflags.sexp (run ./cflags.sh)))


### PR DESCRIPTION
The shell script is local and hence should be prefixed

@hannesm this should fix things