### PR TITLE
conflict with mirage-xen-posix versions that don't install a META file

### DIFF
--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -21,6 +21,7 @@ depopts: [
   "ocaml-freestanding"
 ]
 conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}
 ]
 synopsis: "Bigstring intrinsics and fast blits based on memcpy/memmove"


### PR DESCRIPTION
currently released to opam-repository https://github.com/ocaml/opam-repository/pull/12999