### PR TITLE
Fixing typos

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -56,7 +56,7 @@ function bigstringaf_blit_from_bytes(src, src_off, dst, dst_off, len) {
 }
 
 //Provides: bigstringaf_memcmp_bigstring
-//Requres: caml_ba_get_1, caml_int_compare
+//Requires: caml_ba_get_1, caml_int_compare
 function bigstringaf_memcmp_bigstring(ba1, ba1_off, ba2, ba2_off, len) {
   for (var i = 0; i < len; i++) {
     var c = caml_int_compare(caml_ba_get_1(ba1, ba1_off + i), caml_ba_get_1(ba2, ba2_off + i));
@@ -66,7 +66,7 @@ function bigstringaf_memcmp_bigstring(ba1, ba1_off, ba2, ba2_off, len) {
 }
 
 //Provides: bigstringaf_memcmp_string
-//Requres: caml_ba_get_1, caml_int_compare, caml_string_unsafe_get
+//Requires: caml_ba_get_1, caml_int_compare, caml_string_unsafe_get
 function bigstringaf_memcmp_string(ba, ba_off, str, str_off, len) {
   for (var i = 0; i < len; i++) {
     var c = caml_int_compare(caml_ba_get_1(ba, ba_off + i), caml_string_unsafe_get(str, str_off + i));


### PR DESCRIPTION
Solving issue #26.
//Requres was written instead of //Requires, which was generating a "warning: free variables in primitive code "bigstringaf_memcmp_string" (/home/ziat/.opam/4.07.0/lib/bigstringaf/runtime.js:67)".