### PR TITLE
add dune project name

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.6)
+(name bigstringaf)


### PR DESCRIPTION
Now I hit the error again because of which I wanted to add the dune project name. It triggered during rebuild after ``opam pin bigstring ./``

```
$ opam pin bigstringaf ./
[bigstringaf.0.5.0] synchronised from git+file:///home/madroach/src/bigstringaf#master
bigstringaf is now pinned to git+file:///home/madroach/src/bigstringaf#master (version 0.5.0)

The following actions will be performed:
  - recompile bigstringaf 0.5.0*
Do you want to continue? [Y/n] y
[bigstringaf.0.5.0] synchronised from git+file:///home/madroach/src/bigstringaf#master

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of bigstringaf failed at "/home/madroach/opam/system/bin/dune subst".

#=== ERROR while compiling bigstringaf.0.5.0 ==================================#
# context     2.0.4 | openbsd/x86_64 | ocaml-system.4.07.1 | pinned(git+file:///home/madroach/src/bigstringaf#master#5fc35f1c)
# path        ~/opam/system/.opam-switch/build/bigstringaf.0.5.0
# command     ~/opam/system/bin/dune subst
# exit-code   1
# env-file    ~/opam/log/bigstringaf-31496-dc6e87.env
# output-file ~/opam/log/bigstringaf-31496-dc6e87.out
### output ###
# Error: The project name is not defined, please add a (name <name>) field to your dune-project file.



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build bigstringaf 0.5.0
+- 
- No changes have been performed
[NOTE] Pinning command successful, but your installed packages may be out of sync.
```