### PR TITLE
add Bigstringaf_unix

### DIFF
--- a/bigstringaf-unix.opam
+++ b/bigstringaf-unix.opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/inhabitedtype/bigstringaf"
+bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
+dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" {build}
+  "alcotest" {with-test}
+  "base-bigarray"
+  "ocaml" {>= "4.03.0"}
+]
+synopsis: "I/O for bigstrings"
+description: """
+I/O functions for bigstrings missing from the Unix module.
+"""

--- a/lib/bigstringaf_unix.ml
+++ b/lib/bigstringaf_unix.ml
@@ -1,0 +1,29 @@
+type t =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+let[@inline never] invalid_bounds op buffer_len off len =
+  let message =
+    Printf.sprintf "Bigstringaf_unix.%s invalid range: { buffer_len: %d, off: %d, len: %d }"
+    op buffer_len off len
+  in
+  raise (Invalid_argument message)
+
+let get_bounds name ?(off=0) ?len t =
+  let buffer_len = Bigarray.Array1.dim t in
+  let len = match len with
+    | Some len -> len
+    | None -> buffer_len
+  in
+  if len < 0 || off < 0 || buffer_len - off < len
+  then invalid_bounds name buffer_len off len
+  else (off, len)
+
+external read_fd  : Unix.file_descr -> t -> int -> int -> int = "bigstringaf_read"
+external write_fd : Unix.file_descr -> t -> int -> int -> int = "bigstringaf_write"
+
+let read fd ?off ?len t =
+  let off, len = get_bounds "read" ?off ?len t in
+  read_fd fd t off len
+and write fd ?off ?len t =
+  let off, len = get_bounds "write" ?off ?len t in
+  write_fd fd t off len

--- a/lib/bigstringaf_unix.mli
+++ b/lib/bigstringaf_unix.mli
@@ -1,0 +1,5 @@
+type t =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+val read  : Unix.file_descr -> ?off:int -> ?len:int -> t -> int
+val write : Unix.file_descr -> ?off:int -> ?len:int -> t -> int

--- a/lib/bigstringaf_unix_stubs.c
+++ b/lib/bigstringaf_unix_stubs.c
@@ -1,0 +1,119 @@
+#include <unistd.h>
+#include <caml/mlvalues.h>
+#include <caml/bigarray.h>
+#include <caml/unixsupport.h>
+#include <caml/threads.h>
+
+CAMLprim value
+bigstringaf_read(value vfd, value vba, value voff, value vlen)
+{
+    void *iobuf = ((char *)Caml_ba_data_val(vba)) + Unsigned_long_val(voff);
+#ifdef Handle_val
+    unsigned len;
+    int err;
+
+    if (Descr_kind_val(fd) == KIND_SOCKET) {
+      SOCKET s = Socket_val(fd);
+      caml_release_runtime_system();
+      if ((err = recv(s, iobuf, Unsigned_int_val(vlen), 0)) < 0)
+        err = WSAGetLastError();
+      else {
+        len = err;
+        err = 0;
+      }
+      caml_acquire_runtime_system();
+    } else {
+      HANDLE h = Handle_val(fd);
+      caml_release_runtime_system();
+      if (ReadFile(h, iobuf, Unsigned_int_val(vlen), &len, NULL))
+        err = 0;
+      else {
+check_error:
+        switch (err = GetLastError()) {
+          case ERROR_BROKEN_PIPE:
+            /* This is no error, but just a closed pipe. */
+            err = len = 0;
+            break;
+          case ERROR_MORE_DATA:
+#if 0
+            do {
+              char buf[1024];
+              unsigned dummy_len;
+              if (ReadFile(h, buf, sizeof(buf), &dummy_len, NULL))
+                break;
+              else
+                goto check_error;
+            } while (0);
+#else
+            err = 0;
+#endif
+          default:
+            break;
+        }
+      caml_acquire_runtime_system();
+    }
+    /* GetLastError() and WSAGetLastError() error numbers _are_ compatible,
+     * although not documented this behaviour will hopefully never change. */
+    if (err) {
+      win32_maperr(err);
+      uerror("read", Nothing);
+    }
+    else
+      return Val_int(len);
+
+#else
+    ssize_t ret;
+
+    caml_release_runtime_system();
+    ret = read(Int_val(vfd), iobuf, Unsigned_long_val(vlen));
+    caml_acquire_runtime_system();
+    if (ret < 0) uerror("Bigstringaf.read", Nothing);
+    return Val_long(ret);
+#endif
+}
+
+CAMLprim value
+bigstringaf_write(value vfd, value vba, value voff, value vlen)
+{
+    char *iobuf = ((char *)Caml_ba_data_val(vba)) + Unsigned_long_val(voff);
+#ifdef Handle_val
+    unsigned len;
+    int err;
+
+    if (Descr_kind_val(fd) == KIND_SOCKET) {
+      SOCKET s = Socket_val(vfd);
+      caml_release_runtime_system();
+      if ((err = send(s, iobuf, Unsigned_int_val(vlen), 0)) < 0)
+        err = WSAGetLastError();
+      else {
+        len = err;
+        err = 0;
+      }
+      caml_acquire_runtime_system();
+    } else {
+      HANDLE h = Handle_val(vfd);
+      caml_release_runtime_system();
+      if (WriteFile(h, iobuf, Unsigned_int_val(vlen), &len, NULL))
+        err = 0;
+      else
+        err = GetLastError();
+      caml_acquire_runtime_system();
+    }
+    /* GetLastError() and WSAGetLastError() error numbers _are_ compatible,
+     * although not documented this behaviour will hopefully never change. */
+    if (err) {
+      win32_maperr(err);
+      uerror("Bigstringaf.write", Nothing);
+    }
+    return Val_long(numwritten);
+
+#else
+    ssize_t ret;
+
+    caml_release_runtime_system();
+    ret = write(Int_val(vfd), iobuf, Unsigned_long_val(vlen));
+    caml_acquire_runtime_system();
+    if (ret < 0) uerror("Bigstringaf.write", Nothing);
+    return Val_long(ret);
+#endif
+}

--- a/lib/dune
+++ b/lib/dune
@@ -9,3 +9,15 @@
 
  (js_of_ocaml (javascript_files runtime.js))
 )
+
+(library
+ (name        bigstringaf_unix)
+ (public_name bigstringaf-unix)
+ (libraries   bigarray)
+ (flags       (:standard -safe-string))
+
+ (c_names     bigstringaf_unix_stubs)
+ (c_flags     (-Wall -Wextra -Wpedantic))
+
+ ;(js_of_ocaml (javascript_files runtime.js)) TODO / not available ?
+)


### PR DESCRIPTION
Implementing reads and writes from/to unix filedescriptors / sockets.

* does _not_ depend on bigstringaf
  * should it rather be a separate project?
  * is the naming sensible? maybe better name it ``bigstring-io``?
  * Im just curious, what does the _af_ in bigstringaf stand for?
* Still not tested on Windows
* what about js? can this be implemented for js, too? should it?
