### PR TITLE
Compatibility with mirage+dune

### DIFF
--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "dune" {build}
   "alcotest" {with-test}
-  "base-bigarray"
+  "bigarray-compat"
   "ocaml" {>= "4.03.0"}
 ]
 depopts: [

--- a/lib/bigstringaf.ml
+++ b/lib/bigstringaf.ml
@@ -1,12 +1,12 @@
 type bigstring =
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+  (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
 
 type t = bigstring
 
-let create size = Bigarray.(Array1.create char c_layout size)
+let create size = Bigarray_compat.(Array1.create char c_layout size)
 let empty       = create 0
 
-module BA1 = Bigarray.Array1
+module BA1 = Bigarray_compat.Array1
 
 let length t = BA1.dim t
 

--- a/lib/bigstringaf.mli
+++ b/lib/bigstringaf.mli
@@ -9,7 +9,7 @@
     So here they are. Go crazy. *)
 
 type t =
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+  (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
 
 (** {2 Constructors} *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
  (flags       (:standard -safe-string))
 
  (c_names     bigstringaf_stubs)
- (c_flags     (-Wall -Wextra -Wpedantic))
+ (c_flags     (:standard -Wall -Wextra -Wpedantic))
 
  (js_of_ocaml (javascript_files runtime.js))
 )

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name        bigstringaf)
  (public_name bigstringaf)
- (libraries   bigarray)
+ (libraries   bigarray-compat)
  (flags       (:standard -safe-string))
 
  (c_names     bigstringaf_stubs)

--- a/lib/freestanding/dune
+++ b/lib/freestanding/dune
@@ -2,7 +2,7 @@
  (name        bigstringaf_freestanding)
  (public_name bigstringaf.freestanding)
  (optional)
- (libraries   bigarray ocaml-freestanding)
+ (libraries   bigarray-compat ocaml-freestanding)
  (c_names     bigstringaf_stubs)
  (c_flags     (:include cflags.sexp)))
 

--- a/lib/xen/dune
+++ b/lib/xen/dune
@@ -2,7 +2,7 @@
  (name        bigstringaf_xen)
  (public_name bigstringaf.xen)
  (optional)
- (libraries   bigarray mirage-xen-posix)
+ (libraries   bigarray-compat mirage-xen-posix)
  (c_names     bigstringaf_stubs)
  (c_flags     (:include cflags.sexp)))
 


### PR DESCRIPTION
/cc @TheLortex

A long time ago, we asked to put two sub-packages:
- `bigstringaf.freestanding`
- `bigstringaf.xen`

See #12, #13, #21 and #22.

It's an old trick to give to C stubs right flags to be linked then with the final unikernel with `ocamlbuild` and `ocamlfind`. @TheLortex did a huge work on Mirage to be able to compile an unikernel with `dune`. You can see a precise report [here](https://gist.github.com/TheLortex/f3d92db831b553f6e4eaf2982e3e6427).

The goal of this PR is to move furthermore about compatibility of some packages and what `mirage` will be. 

By the `:standard` expansion in the `dune` file, `mirage` is able to give to `bigstringaf` right flags to compile C stubs (in this case `bigstringaf_stubs`). By this way, `bigstringaf.freestanding` and `bigstringaf.xen` is not needed anymore - this PR does not delete them to keep a compatibility.

Another point, and it's the real purpose of this PR, is to replace `Bigarray` module by `Stdlib.Bigarray` (only available on `ocaml.4.7.0` and upper) or `Bigarray_compat` (a package available [here](https://github.com/mirage/bigarray-compat) where the `Bigarray` module at top differs. `Bigarray_compat` wants to provide only what is needed by `bigstringaf` without `map_file` function for any version of OCaml.

To prepare then, the big move of Mirage to the `dune` build-system, this PR is required - currently compilation was tested locally. If you are interested by the process, I can explain it.

EDIT: GitHub was not happy about my last PR and did not integrate my last commit.