### PR TITLE
update for jsoo#883

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -32,27 +32,21 @@
   ----------------------------------------------------------------------------*/
 
 //Provides: bigstringaf_blit_to_bytes
-//Requires: caml_string_unsafe_set, caml_ba_get_1
+//Requires: caml_ba_blit_ba_to_bytes
 function bigstringaf_blit_to_bytes(src, src_off, dst, dst_off, len) {
-  for (var i = 0; i < len; i++) {
-    caml_string_unsafe_set(dst, dst_off + i, caml_ba_get_1(src, src_off + i));
-  }
+  return caml_ba_blit_ba_to_bytes(src,src_off,dst,dst_off,len);
 }
 
 //Provides: bigstringaf_blit_to_bigstring
-//Requires: caml_ba_set_1, caml_ba_get_1
+//Requires: caml_ba_blit_ba_to_ba
 function bigstringaf_blit_to_bigstring(src, src_off, dst, dst_off, len) {
-  for (var i = 0; i < len; i++) {
-    caml_ba_set_1(dst, dst_off + i, caml_ba_get_1(src, src_off + i));
-  }
+  return caml_ba_blit_ba_to_ba(src, src_off, dst, dst_off, len);
 }
 
 //Provides: bigstringaf_blit_from_bytes
-//Requires: caml_ba_set_1, caml_string_unsafe_get
+//Requires: caml_ba_blit_string_to_ba
 function bigstringaf_blit_from_bytes(src, src_off, dst, dst_off, len) {
-  for (var i = 0; i < len; i++) {
-    caml_ba_set_1(dst, dst_off + i, caml_string_unsafe_get(src, src_off + i));
-  }
+  return caml_ba_blit_string_to_ba(src, src_off, dst, dst_off, len);
 }
 
 //Provides: bigstringaf_memcmp_bigstring

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -32,21 +32,21 @@
   ----------------------------------------------------------------------------*/
 
 //Provides: bigstringaf_blit_to_bytes
-//Requires: caml_ba_blit_ba_to_bytes
+//Requires: caml_bigstring_blit_ba_to_bytes
 function bigstringaf_blit_to_bytes(src, src_off, dst, dst_off, len) {
-  return caml_ba_blit_ba_to_bytes(src,src_off,dst,dst_off,len);
+  return caml_bigstring_blit_ba_to_bytes(src,src_off,dst,dst_off,len);
 }
 
 //Provides: bigstringaf_blit_to_bigstring
-//Requires: caml_ba_blit_ba_to_ba
+//Requires: caml_bigstring_blit_ba_to_ba
 function bigstringaf_blit_to_bigstring(src, src_off, dst, dst_off, len) {
-  return caml_ba_blit_ba_to_ba(src, src_off, dst, dst_off, len);
+  return caml_bigstring_blit_ba_to_ba(src, src_off, dst, dst_off, len);
 }
 
 //Provides: bigstringaf_blit_from_bytes
-//Requires: caml_ba_blit_string_to_ba
+//Requires: caml_bigstring_blit_string_to_ba
 function bigstringaf_blit_from_bytes(src, src_off, dst, dst_off, len) {
-  return caml_ba_blit_string_to_ba(src, src_off, dst, dst_off, len);
+  return caml_bigstring_blit_string_to_ba(src, src_off, dst, dst_off, len);
 }
 
 //Provides: bigstringaf_memcmp_bigstring


### PR DESCRIPTION
Update the js_of_ocaml runtime and use the newly added bigarray blit functions.

- [x] wait for https://github.com/ocsigen/js_of_ocaml/pull/883 to be merge
- [x] wait for an officially release https://github.com/ocaml/opam-repository/pull/15253