### PR TITLE
Bump to OCaml 4.08.0, remove bigarray-compat from dependency chain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-version:
-          - 4.07.1
+          - 4.08.1
           - 4.09.1
           - 4.11.2
           - 4.13.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: 
+on:
   - push
   - pull_request
 
@@ -13,11 +13,11 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-version:
-          - 4.03.0
-          - 4.05.0
-          - 4.07.0
-          - 4.09.0
-          - 4.11.1
+          - 4.07.1
+          - 4.09.1
+          - 4.11.2
+          - 4.13.1
+          - 4.14.0
 
     runs-on: ${{ matrix.os }}
 
@@ -26,14 +26,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-version }}
 
       - name: Deps
-        run: |
-          opam pin add -n bigstringaf .
-          opam install -t --deps-only .
+        run: opam install -t --deps-only .
 
       - name: Build
         run: opam exec -- dune build

--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -6,15 +6,14 @@ homepage: "https://github.com/inhabitedtype/bigstringaf"
 bug-reports: "https://github.com/inhabitedtype/bigstringaf/issues"
 dev-repo: "git+https://github.com/inhabitedtype/bigstringaf.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "dune" {>= "2.6.0"}
   "alcotest" {with-test}
-  "bigarray-compat"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.07.0"}
   "conf-pkg-config" {build}
 ]
 depopts: [

--- a/bigstringaf.opam
+++ b/bigstringaf.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "dune" {>= "2.6.0"}
   "alcotest" {with-test}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "conf-pkg-config" {build}
 ]
 depopts: [

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.6)
 (name bigstringaf)
+(formatting disabled)

--- a/lib/bigstringaf.ml
+++ b/lib/bigstringaf.ml
@@ -1,12 +1,12 @@
 type bigstring =
-  (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 type t = bigstring
 
-let create size = Bigarray_compat.(Array1.create char c_layout size)
+let create size = Bigarray.(Array1.create char c_layout size)
 let empty       = create 0
 
-module BA1 = Bigarray_compat.Array1
+module BA1 = Bigarray.Array1
 
 let length t = BA1.dim t
 

--- a/lib/bigstringaf.mli
+++ b/lib/bigstringaf.mli
@@ -9,7 +9,7 @@
     So here they are. Go crazy. *)
 
 type t =
-  (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 (** {2 Constructors} *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,8 +1,6 @@
 (library
  (name        bigstringaf)
  (public_name bigstringaf)
- (libraries   bigarray-compat)
- (flags       (:standard -safe-string))
 
  (foreign_stubs
   (language c)


### PR DESCRIPTION
Is there need compatibility with arcane OCaml releases? IMHO they can use old released versions of bigstringaf, and there's more value in minimizing the dependency chain.