### PR TITLE
Fix C stubs to avoid returning void

### DIFF
--- a/lib/bigstringaf_stubs.c
+++ b/lib/bigstringaf_stubs.c
@@ -35,31 +35,34 @@
 #include <caml/mlvalues.h>
 #include <caml/bigarray.h>
 
-void
+CAMLprim value
 bigstringaf_blit_to_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
 {
     void *src = ((char *)Caml_ba_data_val(vsrc)) + Unsigned_long_val(vsrc_off),
          *dst = ((char *)String_val(vdst))       + Unsigned_long_val(vdst_off);
     size_t len = Unsigned_long_val(vlen);
     memcpy(dst, src, len);
+    return Val_unit;
 }
 
-void
+CAMLprim value
 bigstringaf_blit_to_bigstring(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
 {
     void *src = ((char *)Caml_ba_data_val(vsrc)) + Unsigned_long_val(vsrc_off),
          *dst = ((char *)Caml_ba_data_val(vdst)) + Unsigned_long_val(vdst_off);
     size_t len = Unsigned_long_val(vlen);
     memmove(dst, src, len);
+    return Val_unit;
 }
 
-void
+CAMLprim value
 bigstringaf_blit_from_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
 {
     void *src = ((char *)String_val(vsrc))       + Unsigned_long_val(vsrc_off),
          *dst = ((char *)Caml_ba_data_val(vdst)) + Unsigned_long_val(vdst_off);
     size_t len = Unsigned_long_val(vlen);
     memcpy(dst, src, len);
+    return Val_unit;
 }
 
 CAMLprim value


### PR DESCRIPTION
Fix C stubs to return `Val_unit` instead of `void`. Prior to this PR, code like this would segfault:

```ocaml
utop # let t = Bigstringaf.create 100;;
utop # let q = Queue.create ();;
utop # Queue.add (Bigstringaf.blit_to_bytes t ~src_off:50 (Bytes.create 100) ~dst_off:50 ~len:50) q;;
- : unit = ()
utop # Gc.full_major ();;
Segmentation fault (core dumped)  
```