### PR TITLE
Adds an example (OCaml Examples Project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ make test
 ## License
 
 BSD3, see LICENSE file for its text.
+
+## Examples
+
+See examples/README.md for a simple usage example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# bigstringaf
+
+This example is for the bigstringaf library
+
+https://opam.ocaml.org/packages/bigstringaf
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe`
+
+# Cleaning up
+
+`dune clean`

--- a/examples/bin/dune
+++ b/examples/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries bigstringaf))

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -1,0 +1,23 @@
+let go () =
+  (* A 20Mb bigstring *)
+  let b = Bigstringaf.create (1024 * 1024 * 20) in
+  (* Get the first megabyte as a new string *)
+  let b2 = Bigstringaf.copy ~off:0 ~len:(1024 * 1024) b in
+  (* Or, as a view on the original string, with no copying *)
+  let b3 = Bigstringaf.sub ~off:0 ~len:(1024 * 1024) in
+  (* Get a string from a section of a bigstring (avoids copy then convert to string) *)
+  let s = Bigstringaf.substring b ~off:0 ~len:(1024 * 1024) in
+  (* Get a 64 bit big endian value *)
+  let i64 = Bigstringaf.get_int64_be b 0 in
+  (* Blitting. Here from string to bigstring *)
+  Bigstringaf.blit_from_string s ~src_off:0 b ~dst_off:(1024 * 1024) ~len:(1024 * 1024);
+  (* Compare *)
+  let cmp = Bigstringaf.memcmp b 0 b2 0 (1024 * 1024) in
+  (* Look for a byte *)
+  let found = Bigstringaf.memchr b 0 '\n' (1024 * 1024) in
+    Printf.printf "Position of first \\n: %i\n" found
+
+let () =
+  match Sys.argv with
+  | [|_|] -> go ()
+  | _ -> Printf.eprintf "bigstringaf example: unknown command line\n"

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name bigstringaf_example)

--- a/examples/dune-workspace
+++ b/examples/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
Hello!

This pull request adds some examples to Bigstringaf. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please give any comments you have on this programme.